### PR TITLE
Typehint all classes that use commands

### DIFF
--- a/examples/3-intermediate-custom-naming-conventions.php
+++ b/examples/3-intermediate-custom-naming-conventions.php
@@ -13,13 +13,14 @@ require __DIR__ . '/repeated-sample-code.php';
  * We can write a custom MethodNameInflector for that:
  */
 
+use Tactician\CommandBus\Command;
 use Tactician\CommandBus\Handler\MethodNameInflector\MethodNameInflector;
 
 class MyCustomInflector implements MethodNameInflector
 {
     // You can use the command and commandHandler to generate any name you
     // prefer but here, we'll always return the same one.
-    public function inflect($command, $commandHandler)
+    public function inflect(Command $command, $commandHandler)
     {
         return 'handle';
     }

--- a/examples/4-advanced-custom-handler-loading.php
+++ b/examples/4-advanced-custom-handler-loading.php
@@ -10,6 +10,8 @@ require __DIR__ . '/repeated-sample-code.php';
  * We can create a custom HandlerLocator for that.
  */
 use Tactician\CommandBus\Handler\Locator\HandlerLocator;
+use Tactician\CommandBus\Command;
+
 class ContainerBasedHandlerLocator implements HandlerLocator
 {
     protected $container;
@@ -19,7 +21,7 @@ class ContainerBasedHandlerLocator implements HandlerLocator
         $this->container = $container;
     }
 
-    public function getHandlerForCommand($command)
+    public function getHandlerForCommand(Command $command)
     {
         // This is a cheesy naming strategy but it's just an example
         $handlerId = 'app.handler.' . get_class($command);

--- a/src/Handler/Locator/HandlerLocator.php
+++ b/src/Handler/Locator/HandlerLocator.php
@@ -2,6 +2,8 @@
 
 namespace Tactician\CommandBus\Handler\Locator;
 
+use Tactician\CommandBus\Command;
+
 /**
  * Service locator for handler objects
  *
@@ -13,8 +15,8 @@ interface HandlerLocator
     /**
      * Retrieves the handler for a specified command
      *
-     * @param object $command
+     * @param Command $command
      * @return mixed
      */
-    public function getHandlerForCommand($command);
+    public function getHandlerForCommand(Command $command);
 }

--- a/src/Handler/Locator/InMemoryLocator.php
+++ b/src/Handler/Locator/InMemoryLocator.php
@@ -2,6 +2,7 @@
 
 namespace Tactician\CommandBus\Handler\Locator;
 
+use Tactician\CommandBus\Command;
 use Tactician\CommandBus\Exception\MissingHandlerException;
 
 /**
@@ -38,11 +39,11 @@ class InMemoryLocator implements HandlerLocator
     /**
      * Retrieve handler for the given command
      *
-     * @param object $command
+     * @param Command $command
      * @return object
      * @throws MissingHandlerException
      */
-    public function getHandlerForCommand($command)
+    public function getHandlerForCommand(Command $command)
     {
         $className = get_class($command);
 

--- a/src/Handler/MethodNameInflector/HandleClassNameInflector.php
+++ b/src/Handler/MethodNameInflector/HandleClassNameInflector.php
@@ -1,6 +1,8 @@
 <?php
 namespace Tactician\CommandBus\Handler\MethodNameInflector;
 
+use Tactician\CommandBus\Command;
+
 /**
  * Assumes the method is handle + the last portion of the class name.
  *
@@ -13,7 +15,7 @@ class HandleClassNameInflector implements MethodNameInflector
     /**
      * {@inheritdoc}
      */
-    public function inflect($command, $commandHandler)
+    public function inflect(Command $command, $commandHandler)
     {
         $commandName = get_class($command);
 

--- a/src/Handler/MethodNameInflector/InvokeInflector.php
+++ b/src/Handler/MethodNameInflector/InvokeInflector.php
@@ -1,6 +1,8 @@
 <?php
 namespace Tactician\CommandBus\Handler\MethodNameInflector;
 
+use Tactician\CommandBus\Command;
+
 /**
  * Handle command by calling the __invoke magic method. Handy for single
  * use classes or closures.
@@ -10,7 +12,7 @@ class InvokeInflector implements MethodNameInflector
     /**
      * {@inheritdoc}
      */
-    public function inflect($command, $commandHandler)
+    public function inflect(Command $command, $commandHandler)
     {
         return '__invoke';
     }

--- a/src/Handler/MethodNameInflector/MethodNameInflector.php
+++ b/src/Handler/MethodNameInflector/MethodNameInflector.php
@@ -1,6 +1,8 @@
 <?php
 namespace Tactician\CommandBus\Handler\MethodNameInflector;
 
+use Tactician\CommandBus\Command;
+
 /**
  * Deduce the method name to call on the command handler based on the command
  * and handler instances.
@@ -10,9 +12,9 @@ interface MethodNameInflector
     /**
      * Return the method name to call on the command handler and return it.
      *
-     * @param object $command
+     * @param Command $command
      * @param object $commandHandler
      * @return string
      */
-    public function inflect($command, $commandHandler);
+    public function inflect(Command $command, $commandHandler);
 }

--- a/tests/Fixtures/Command/CommandWithoutNamespace.php
+++ b/tests/Fixtures/Command/CommandWithoutNamespace.php
@@ -1,4 +1,7 @@
 <?php
+// @codingStandardsIgnoreStart
+// We must exclude the coding standards from this file, otherwise it will fail
+// due to the lack of a namespace.
 
 use Tactician\CommandBus\Command;
 
@@ -9,3 +12,4 @@ use Tactician\CommandBus\Command;
 class CommandWithoutNamespace implements Command
 {
 }
+// @codingStandardsIgnoreEnd

--- a/tests/Fixtures/Command/CommandWithoutNamespace.php
+++ b/tests/Fixtures/Command/CommandWithoutNamespace.php
@@ -1,0 +1,11 @@
+<?php
+
+use Tactician\CommandBus\Command;
+
+/**
+ * This is a command without any namespace that we can use to test edge cases
+ * on the MethodNameInflectors
+ */
+class CommandWithoutNamespace implements Command
+{
+}

--- a/tests/Fixtures/Handler/ConcreteMethodsHandler.php
+++ b/tests/Fixtures/Handler/ConcreteMethodsHandler.php
@@ -11,8 +11,4 @@ class ConcreteMethodsHandler
     public function handleTaskCompletedCommand($command)
     {
     }
-
-    public function handlestdClass($command)
-    {
-    }
 }

--- a/tests/Handler/MethodNameInflector/HandleClassNameInflectorTest.php
+++ b/tests/Handler/MethodNameInflector/HandleClassNameInflectorTest.php
@@ -4,7 +4,7 @@ namespace Tactician\CommandBus\Tests\Handler\MethodNameInflector;
 use Tactician\CommandBus\Handler\MethodNameInflector\HandleClassNameInflector;
 use Tactician\CommandBus\Tests\Fixtures\Command\CompleteTaskCommand;
 use Tactician\CommandBus\Tests\Fixtures\Handler\ConcreteMethodsHandler;
-use stdClass;
+use CommandWithoutNamespace;
 
 class HandleClassNameInflectorTest extends \PHPUnit_Framework_TestCase
 {
@@ -26,11 +26,11 @@ class HandleClassNameInflectorTest extends \PHPUnit_Framework_TestCase
 
     public function testHandlesClassesWithoutNamespace()
     {
-        $stdClass = new stdClass();
+        $command = new CommandWithoutNamespace();
 
         $this->assertEquals(
-            'handlestdClass',
-            $this->inflector->inflect($stdClass, $this->mockHandler)
+            'handleCommandWithoutNamespace',
+            $this->inflector->inflect($command, $this->mockHandler)
         );
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,3 +2,6 @@
 /** @var \Composer\Autoload\ClassLoader $loader */
 $loader = require __DIR__.'/../vendor/autoload.php';
 $loader->addPsr4('Tactician\\CommandBus\\Tests\\', __DIR__);
+
+// In lieu of autoloading hacks, we'll just do it this way.
+require_once __DIR__.'/Fixtures/Command/CommandWithoutNamespace.php';


### PR DESCRIPTION
Finishes the work started in PR #3. Adding the typehint meant we could
no longer use stdClass for one of the inflector tests (since it doesn't
implement the Command interface) so this was switched to a fixture.
